### PR TITLE
fix(container.py): Fix heigh to height

### DIFF
--- a/book/src/ch02/src/container.py
+++ b/book/src/ch02/src/container.py
@@ -12,7 +12,7 @@ def mark_coordinate(grid, coord):
 class Boundaries:
     def __init__(self, width, height):
         self.width = width
-        self.height = heigh
+        self.height = height
 
     def __contains__(self, coord):
         x, y = coord


### PR DESCRIPTION
Hi,
I'm a reader of `Clean Code in Python: Develop Maintainable and Efficient Code, 2nd Edition`. I was just looking at `container.py` and noticed that there is a typo there. `heigh` should be correctly typed as `height`. Otherwise, it'll cause an error.

Thanks,
Nayeon :)