### PR TITLE
debug descriptors_cpython_3.py

### DIFF
--- a/book/src/ch06/src/descriptors_cpython_3.py
+++ b/book/src/ch06/src/descriptors_cpython_3.py
@@ -14,7 +14,7 @@ class ClassMethod:
         return self.method(*args, **kwargs)
 
     def __get__(self, instance, owner):
-        return MethodType(self.method, owner)
+        return MethodType(self, owner)
 
 
 class MyClass:


### PR DESCRIPTION
In the original code, `__call__` of "ClassMethod" doesn't work.