### PR TITLE
Improving type hints

### DIFF
--- a/book/src/ch05/src/decorator_parametrized_1.py
+++ b/book/src/ch05/src/decorator_parametrized_1.py
@@ -4,7 +4,7 @@ Parametrized decorators using functions
 """
 
 from functools import wraps
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Type
 
 from decorator_function_1 import ControlledException
 from log import logger
@@ -15,7 +15,7 @@ _DEFAULT_RETRIES_LIMIT = 3
 
 def with_retry(
     retries_limit: int = _DEFAULT_RETRIES_LIMIT,
-    allowed_exceptions: Optional[Sequence[Exception]] = None,
+    allowed_exceptions: Optional[Sequence[Type[Exception]]] = None,
 ):
     allowed_exceptions = allowed_exceptions or (ControlledException,)  # type: ignore
 

--- a/book/src/ch05/src/decorator_parametrized_2.py
+++ b/book/src/ch05/src/decorator_parametrized_2.py
@@ -3,7 +3,7 @@
 Parametrized decorators using callable objects.
 """
 from functools import wraps
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Type
 
 from decorator_function_1 import ControlledException
 from log import logger
@@ -15,7 +15,7 @@ class WithRetry:
     def __init__(
         self,
         retries_limit: int = _DEFAULT_RETRIES_LIMIT,
-        allowed_exceptions: Optional[Sequence[Exception]] = None,
+        allowed_exceptions: Optional[Sequence[Type[Exception]]] = None,
     ) -> None:
         self.retries_limit = retries_limit
         self.allowed_exceptions = allowed_exceptions or (ControlledException,)


### PR DESCRIPTION
Reading your (great!) book and i think the type hints can/must be improved, since decorator function accepts not the instances of exceptions classes, rather classes themselves.
What do you think?